### PR TITLE
Fix: switch 'connect additional device' link to use goto

### DIFF
--- a/src/components/home/Authed.svelte
+++ b/src/components/home/Authed.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { goto } from '$app/navigation'
+
   import { sessionStore } from '../../stores'
 </script>
 
@@ -24,8 +26,8 @@
       devices as they’d like. For recoverability, we recommend they always
       connect at least two.
     </p>
-    <a class="btn btn-primary" href="/delegate-account">
+    <button class="btn btn-primary" on:click={() => goto('/delegate-account')}>
       Connect an additional device
-    </a>
+    </button>
   </div>
 </div>

--- a/src/components/settings/ConnectedDevices.svelte
+++ b/src/components/settings/ConnectedDevices.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { goto } from '$app/navigation'
+
   import { sessionStore } from '$src/stores'
 </script>
 
@@ -9,7 +11,7 @@
   {:else}
     <p>You have no other connected devices.</p>
   {/if}
-  <a class="btn btn-outline" href="/delegate-account">
+  <button class="btn btn-outline" on:click={() => goto('/delegate-account')}>
     Connect an additional device
-  </a>
+  </button>
 </div>


### PR DESCRIPTION
# Description

Updating the `href="/delegate-account"` links in the app to use `goto` instead. For some reason using `href` to go to the `delegated-account` page creates some issues while device linking. Will have to dig further into that

## Link to issue

https://github.com/oddsdk/odd-app-template/issues/125

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots/Screencaps

https://www.loom.com/share/d1ddf7ca6cfc440cb622a7487aeb480f
