### PR TITLE
Fix account linking issues

### DIFF
--- a/src/lib/auth/account.ts
+++ b/src/lib/auth/account.ts
@@ -122,3 +122,32 @@ export const loadAccount = async (hashedUsername: string, fullUsername: string):
     backupCreated: backupStatus.created
   }))
 }
+
+export async function waitForDataRoot(username: string): Promise<void> {
+  const session = getStore(sessionStore)
+  const reference = session.program?.components.reference
+  const EMPTY_CID = 'Qmc5m94Gu7z62RC8waSKkZUrCCBJPyHbkpmGzEePxy2oXJ'
+
+  if (!reference) throw new Error('Program must be initialized to check for data root')
+
+  let dataRoot = await reference.dataRoot.lookup(username)
+
+  if (dataRoot.toString() !== EMPTY_CID) return
+
+  return new Promise((resolve) => {
+    const maxRetries = 50
+    let attempt = 0
+
+    const dataRootInterval = setInterval(async () => {
+      dataRoot = await reference.dataRoot.lookup(username)
+
+      if (dataRoot.toString() === EMPTY_CID && attempt < maxRetries) {
+        attempt++
+        return
+      }
+
+      clearInterval(dataRootInterval)
+      resolve()
+    }, 500)
+  })
+}

--- a/src/routes/link-device/+page.svelte
+++ b/src/routes/link-device/+page.svelte
@@ -6,6 +6,8 @@
   import { addNotification } from '$lib/notifications'
   import { createAccountLinkingConsumer } from '$lib/auth/linking'
   import { loadAccount } from '$lib/auth/account'
+  import { sessionStore } from '../../stores'
+  import { waitForDataRoot } from '$lib/auth/account'
   import type { LinkDeviceView } from '$lib/views'
   import FilesystemActivity from '$components/common/FilesystemActivity.svelte'
   import LinkDevice from '$components/auth/link-device/LinkDevice.svelte'
@@ -33,6 +35,8 @@
       if (approved) {
         view = 'load-filesystem'
 
+        // See https://github.com/oddsdk/ts-odd/issues/529
+        await waitForDataRoot(hashedUsername)
         await loadAccount(hashedUsername, fullUsername)
 
         addNotification("You're now connected!", 'success')
@@ -51,7 +55,9 @@
     goto('/')
   }
 
-  initAccountLinkingConsumer()
+  if (!$sessionStore.session) {
+    initAccountLinkingConsumer()
+  }
 </script>
 
 <input type="checkbox" id="my-modal-5" checked class="modal-toggle" />


### PR DESCRIPTION
# Description

This PR fixes account linking bugs.

### Failed to fetch root DID

The account linking consumer is initialized a second time after account linking. It seems the `link-device` page is loaded a second time.

The fix here is guarding the initialization call when we have a session, which prevents the account linking consumer from starting unnecessarily.

https://github.com/oddsdk/odd-app-template/blob/435a235ae68c9fa01df4f176c93b427c2253718f/src/routes/link-device/%2Bpage.svelte#L58-L60

### Could not parse a valid private tree using the given key

The file system data root may not be available immediately after linking completes. This issue is documented in https://github.com/oddsdk/ts-odd/issues/529. When this issue occurs, the result is a `Error: Could not parse a valid private tree using the given key`, but only after a reload.

The fix for this issue is waiting in the account linking consumer until the data root is available (when it is a non-empty CID).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

Create a new account and link it on a second device immediately and as quickly as possible. No errors should occur and the file system should load and work as expected.